### PR TITLE
Remove paper mention from anticheat list

### DIFF
--- a/anticheat.md
+++ b/anticheat.md
@@ -1,7 +1,7 @@
 # Reasoning
 - See main principle 3
 # Anticheats presents
-- Paper anti-xray
+- Anti-xray
 - GrimAC
 # The "treadmill problem"
 *in software development - a task that occupies an infinite amount of a programmer's time, because there's endless upkeep*


### PR DESCRIPTION
Some people may prefer to host a server without paper. We should give them that option.